### PR TITLE
Add 'policy incoming' and 'policy outgoing' subcommands

### DIFF
--- a/client.go
+++ b/client.go
@@ -400,6 +400,62 @@ func (c *Client) Unshare(ctx context.Context, recordType string, readerID string
 	return nil
 }
 
+// OutgoingSharingPolicy contains information about who and what types of
+// records I have shared with.
+type OutgoingSharingPolicy struct {
+	ReaderID   string `json:"reader_id"`
+	Type       string `json:"record_type"`
+	ReaderName string `json:"reader_name"`
+}
+
+// GetOutgoingSharing returns a list of readers and types of records that
+// I am currently sharing.
+func (c *Client) GetOutgoingSharing(ctx context.Context) ([]OutgoingSharingPolicy, error) {
+	u := fmt.Sprintf("%s/v1/storage/policy/outgoing", c.apiURL())
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var osp []OutgoingSharingPolicy
+
+	resp, err := c.rawCall(ctx, req, &osp)
+	if err != nil {
+		return nil, err
+	}
+
+	defer closeResp(resp)
+	return osp, nil
+}
+
+// IncomingSharingPolicy contains information about who has shared what type
+// of records with me.
+type IncomingSharingPolicy struct {
+	WriterID   string `json:"writer_id"`
+	Type       string `json:"record_type"`
+	WriterName string `json:"writer_name"`
+}
+
+// GetIncomingSharing returns a list of writers and types of records that are
+// currently shared with me.
+func (c *Client) GetIncomingSharing(ctx context.Context) ([]IncomingSharingPolicy, error) {
+	u := fmt.Sprintf("%s/v1/storage/policy/incoming", c.apiURL())
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var isp []IncomingSharingPolicy
+
+	resp, err := c.rawCall(ctx, req, &isp)
+	if err != nil {
+		return nil, err
+	}
+
+	defer closeResp(resp)
+	return isp, nil
+}
+
 // EventSource represents an open socket to the e3db Event source.
 type EventSource struct {
 	commands chan subscription

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -133,6 +133,21 @@ func TestShare(t *testing.T) {
 	}
 }
 
+func haveSharedWith(id, recordType string) (bool, error) {
+	osps, err := client.GetOutgoingSharing(context.Background())
+	if err != nil {
+		return false, err
+	}
+
+	for _, osp := range osps {
+		if osp.ReaderID == id && osp.Type == recordType {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // TestShareThenUnshare should share then revoke sharing
 func TestShareThenUnshare(t *testing.T) {
 	rec1 := client.NewRecord("test-share-data")
@@ -147,9 +162,32 @@ func TestShareThenUnshare(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = client.Unshare(context.Background(), "test-share-date", TEST_SHARE_CLIENT)
+	isShared, err := haveSharedWith(TEST_SHARE_CLIENT, "test-share-data")
+	if err != nil {
+		t.Errorf("share failed: %s", err)
+	} else if !isShared {
+		t.Error("share: have not shared with client")
+	}
+
+	err = client.Unshare(context.Background(), "test-share-data", TEST_SHARE_CLIENT)
 	if err != nil {
 		t.Errorf("Unshare failed: %s", err)
+	}
+
+	isShared, err = haveSharedWith(TEST_SHARE_CLIENT, "test-share-data")
+	if err != nil {
+		t.Errorf("unshare failed: %s", err)
+	} else if isShared {
+		t.Error("unshare: have unexpectedly shared with client")
+	}
+}
+
+// TestIncomingSharing currently tests that the incoming sharing endpoint
+// works and returns a non-error result.
+func TestIncomingSharing(t *testing.T) {
+	_, err := client.GetIncomingSharing(context.Background())
+	if err != nil {
+		t.Errorf("TestIncomingSharing: %s", err)
 	}
 }
 

--- a/cmd/e3db/main.go
+++ b/cmd/e3db/main.go
@@ -579,6 +579,48 @@ func cmdFeedback(cmd *cli.Cmd) {
 	}
 }
 
+func cmdPolicyOutgoing(cmd *cli.Cmd) {
+	cmd.Action = func() {
+		client := options.getClient()
+		osps, err := client.GetOutgoingSharing(context.Background())
+		if err != nil {
+			dieErr(err)
+		}
+
+		for _, osp := range osps {
+			var displayName *string
+			if osp.ReaderName != "" {
+				displayName = &osp.ReaderName
+			} else {
+				displayName = &osp.ReaderID
+			}
+
+			fmt.Printf("%-40s %s\n", *displayName, osp.Type)
+		}
+	}
+}
+
+func cmdPolicyIncoming(cmd *cli.Cmd) {
+	cmd.Action = func() {
+		client := options.getClient()
+		isps, err := client.GetIncomingSharing(context.Background())
+		if err != nil {
+			dieErr(err)
+		}
+
+		for _, isp := range isps {
+			var displayName *string
+			if isp.WriterName != "" {
+				displayName = &isp.WriterName
+			} else {
+				displayName = &isp.WriterID
+			}
+
+			fmt.Printf("%-40s %s\n", *displayName, isp.Type)
+		}
+	}
+}
+
 func main() {
 	app := cli.App("e3db-cli", "E3DB Command Line Interface")
 
@@ -595,6 +637,10 @@ func main() {
 	app.Command("delete", "delete a record", cmdDelete)
 	app.Command("share", "share records with another client", cmdShare)
 	app.Command("unshare", "stop sharing records with another client", cmdUnshare)
+	app.Command("policy", "operations on sharing policy", func(cmd *cli.Cmd) {
+		cmd.Command("incoming", "list incoming sharing policy (who shares with me?)", cmdPolicyIncoming)
+		cmd.Command("outgoing", "list outgoing sharing policy (who have I shared with?)", cmdPolicyOutgoing)
+	})
 	app.Command("subscribe", "subscribe to a stream of events produced by a client", cmdSubscribe)
 	app.Command("feedback", "provde e3db feedback to Tozny", cmdFeedback)
 	app.Command("file", "work with small files", func(cmd *cli.Cmd) {


### PR DESCRIPTION
- These list incoming and outgoing sharing policy by querying new endpoints on the storage service (see feature/query-sharing branch of service)