### PR TITLE
Optimistic Locking Support; SDK Parity

### DIFF
--- a/client.go
+++ b/client.go
@@ -293,22 +293,15 @@ func (c *Client) Read(ctx context.Context, recordID string) (*Record, error) {
 
 // Write writes a new encrypted record to the database. Returns the new record (with
 // the original, unencrypted data)
-func (c *Client) Write(ctx context.Context, recordType string, data *map[string]string, plain *map[string]string) (*Record, error) {
-	var plainMap map[string]string
-	if plain == nil {
-		plainMap = nil
-	} else {
-		plainMap = *plain
-	}
-
+func (c *Client) Write(ctx context.Context, recordType string, data map[string]string, plain map[string]string) (*Record, error) {
 	record := &Record{
 		Meta: Meta{
 			Type:     recordType,
 			WriterID: c.Options.ClientID,
 			UserID:   c.Options.ClientID, // for now
-			Plain:    plainMap,
+			Plain:    plain,
 		},
-		Data: *data,
+		Data: data,
 	}
 
 	encryptedRecord, err := c.encryptRecord(ctx, record)

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -78,7 +78,7 @@ func TestGetClientInfo(t *testing.T) {
 func TestWriteRead(t *testing.T) {
 	data := make(map[string]string)
 	data["message"] = "Hello, world!"
-	rec1, err := client.Write(context.Background(), "test-data", &data, nil)
+	rec1, err := client.Write(context.Background(), "test-data", data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestWriteRead(t *testing.T) {
 func TestWriteThenDelete(t *testing.T) {
 	data := make(map[string]string)
 	data["message"] = "Hello, world!"
-	record, err := client.Write(context.Background(), "test-data", &data, nil)
+	record, err := client.Write(context.Background(), "test-data", data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestWriteThenDelete(t *testing.T) {
 func TestShare(t *testing.T) {
 	data := make(map[string]string)
 	data["message"] = "Hello, world!"
-	_, err := client.Write(context.Background(), "test-data", &data, nil)
+	_, err := client.Write(context.Background(), "test-data", data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestShare(t *testing.T) {
 func TestShareThenUnshare(t *testing.T) {
 	data := make(map[string]string)
 	data["message"] = "Hello, world!"
-	_, err := client.Write(context.Background(), "test-share-data", &data, nil)
+	_, err := client.Write(context.Background(), "test-share-data", data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestEvents(t *testing.T) {
 func TestCounter(t *testing.T) {
 	data := make(map[string]string)
 	data["counter"] = "1"
-	rec1, err := client.Write(context.Background(), "test-data", &data, nil)
+	rec1, err := client.Write(context.Background(), "test-data", data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 
@@ -75,12 +76,13 @@ func TestGetClientInfo(t *testing.T) {
 }
 
 func TestWriteRead(t *testing.T) {
-	rec1 := client.NewRecord("test-data")
-	rec1.Data["message"] = "Hello, world!"
-	recordID, err := client.Write(context.Background(), rec1)
+	data := make(map[string]string)
+	data["message"] = "Hello, world!"
+	rec1, err := client.Write(context.Background(), "test-data", &data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	recordID := rec1.Meta.RecordID
 
 	rec2, err := client.Read(context.Background(), recordID)
 	if err != nil {
@@ -106,12 +108,13 @@ func TestWriteRead(t *testing.T) {
 
 // TestWriteThenDelete should delete a record
 func TestWriteThenDelete(t *testing.T) {
-	rec1 := client.NewRecord("test-data")
-	rec1.Data["message"] = "Hello, world!"
-	recordID, err := client.Write(context.Background(), rec1)
+	data := make(map[string]string)
+	data["message"] = "Hello, world!"
+	record, err := client.Write(context.Background(), "test-data", &data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	recordID := record.Meta.RecordID
 
 	err = client.Delete(context.Background(), recordID)
 	if err != nil {
@@ -120,9 +123,9 @@ func TestWriteThenDelete(t *testing.T) {
 }
 
 func TestShare(t *testing.T) {
-	rec1 := client.NewRecord("test-data")
-	rec1.Data["message"] = "Hello, world!"
-	_, err := client.Write(context.Background(), rec1)
+	data := make(map[string]string)
+	data["message"] = "Hello, world!"
+	_, err := client.Write(context.Background(), "test-data", &data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,9 +138,9 @@ func TestShare(t *testing.T) {
 
 // TestShareThenUnshare should share then revoke sharing
 func TestShareThenUnshare(t *testing.T) {
-	rec1 := client.NewRecord("test-share-data")
-	rec1.Data["message"] = "Hello, world!"
-	_, err := client.Write(context.Background(), rec1)
+	data := make(map[string]string)
+	data["message"] = "Hello, world!"
+	_, err := client.Write(context.Background(), "test-share-data", &data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,5 +187,59 @@ func TestEvents(t *testing.T) {
 	source.Unsubscribe(channel)
 
 	for range done {
+	}
+}
+
+func TestCounter(t *testing.T) {
+	data := make(map[string]string)
+	data["counter"] = "1"
+	rec1, err := client.Write(context.Background(), "test-data", &data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordID := rec1.Meta.RecordID
+
+	// Update w/ correct version
+	err = client.Update(context.Background(), rec1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec1.Data["counter"] = "X"
+	rec1.Meta.Version = "6bc381c7-a41d-45ae-89aa-0890ad654673"
+	// should not update
+	err = client.Update(context.Background(), rec1)
+	if err == nil {
+		t.Fatal("Should not be able to update record with wrong version.")
+	}
+
+	if httpErr, ok := err.(*httpError); ok {
+		if httpErr.StatusCode != http.StatusConflict {
+			t.Fatal("Version conflict not reported.")
+		}
+	}
+
+	rec2, err := client.Read(context.Background(), recordID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rec2.Data["counter"] != "1" {
+		t.Fatal("Counter had wrong value.")
+	}
+
+	rec2.Data["counter"] = "2"
+	err = client.Update(context.Background(), rec2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec3, err := client.Read(context.Background(), recordID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rec3.Data["counter"] != "2" {
+		t.Fatal("Counter had wrong value")
 	}
 }

--- a/cmd/e3db/main.go
+++ b/cmd/e3db/main.go
@@ -584,7 +584,7 @@ func cmdFeedback(cmd *cli.Cmd) {
 func main() {
 	app := cli.App("e3db-cli", "E3DB Command Line Interface")
 
-	app.Version("v version", "e3db-cli 1.0.1")
+	app.Version("v version", "e3db-cli 2.0.0-rc1")
 
 	options.Logging = app.BoolOpt("d debug", false, "enable debug logging")
 	options.Profile = app.StringOpt("p profile", "", "e3db configuration profile")

--- a/cmd/e3db/main.go
+++ b/cmd/e3db/main.go
@@ -213,7 +213,7 @@ func cmdWrite(cmd *cli.Cmd) {
 			dieErr(err)
 		}
 
-		record, err := client.Write(context.Background(), *recordType, &jsonData, nil)
+		record, err := client.Write(context.Background(), *recordType, jsonData, nil)
 		if err != nil {
 			dieErr(err)
 		}
@@ -265,7 +265,7 @@ func cmdWriteFile(cmd *cli.Cmd) {
 		data["contents"] = base64.RawURLEncoding.EncodeToString(buf.Bytes())
 		data["size"] = strconv.FormatInt(fi.Size(), 10)
 
-		record, err := client.Write(context.Background(), *recordType, &data, nil)
+		record, err := client.Write(context.Background(), *recordType, data, nil)
 		if err != nil {
 			dieErr(err)
 		}
@@ -565,7 +565,7 @@ func cmdFeedback(cmd *cli.Cmd) {
 		data := make(map[string]string)
 		data["comment"] = text
 
-		id, err := client.Write(context.Background(), "feedback", &data, nil)
+		id, err := client.Write(context.Background(), "feedback", data, nil)
 		if err != nil {
 			dieErr(err)
 		}

--- a/cmd/e3db/main.go
+++ b/cmd/e3db/main.go
@@ -206,18 +206,19 @@ func cmdWrite(cmd *cli.Cmd) {
 			recordData = *data
 		}
 
-		record := client.NewRecord(*recordType)
-		err := json.NewDecoder(strings.NewReader(recordData)).Decode(&record.Data)
+		jsonData := make(map[string]string)
+
+		err := json.NewDecoder(strings.NewReader(recordData)).Decode(&jsonData)
 		if err != nil {
 			dieErr(err)
 		}
 
-		id, err := client.Write(context.Background(), record)
+		record, err := client.Write(context.Background(), *recordType, &jsonData, nil)
 		if err != nil {
 			dieErr(err)
 		}
 
-		fmt.Println(id)
+		fmt.Println(record.Meta.RecordID)
 	}
 }
 
@@ -238,7 +239,7 @@ func cmdWriteFile(cmd *cli.Cmd) {
 
 	cmd.Action = func() {
 		client := options.getClient()
-		record := client.NewRecord(*recordType)
+		data := make(map[string]string)
 
 		f, err := os.Open(*filename)
 		if err != nil {
@@ -260,16 +261,16 @@ func cmdWriteFile(cmd *cli.Cmd) {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(f)
 
-		record.Data["filename"] = fi.Name()
-		record.Data["contents"] = base64.RawURLEncoding.EncodeToString(buf.Bytes())
-		record.Data["size"] = strconv.FormatInt(fi.Size(), 10)
+		data["filename"] = fi.Name()
+		data["contents"] = base64.RawURLEncoding.EncodeToString(buf.Bytes())
+		data["size"] = strconv.FormatInt(fi.Size(), 10)
 
-		id, err := client.Write(context.Background(), record)
+		record, err := client.Write(context.Background(), *recordType, &data, nil)
 		if err != nil {
 			dieErr(err)
 		}
 
-		fmt.Println(id)
+		fmt.Println(record.Meta.RecordID)
 	}
 }
 
@@ -561,9 +562,10 @@ func cmdFeedback(cmd *cli.Cmd) {
 		}
 
 		// Write feedback to the database
-		record := client.NewRecord("feedback")
-		record.Data["comment"] = text
-		id, err := client.Write(context.Background(), record)
+		data := make(map[string]string)
+		data["comment"] = text
+
+		id, err := client.Write(context.Background(), "feedback", &data, nil)
 		if err != nil {
 			dieErr(err)
 		}


### PR DESCRIPTION
* Added `version` header to  Meta structure, to support safe update endpoint.
* Added `Update` method to client
* Modified `Write` so it creates a record (similar to Ruby SDK). Removed `NewRecord` as it's no longer necessary.
* Updated version (CLI) to `2.0.0-rc1`.