### PR TITLE
Delete AKs when revoking sharing

### DIFF
--- a/client.go
+++ b/client.go
@@ -415,8 +415,6 @@ func (c *Client) Share(ctx context.Context, recordType string, readerID string) 
 // Unshare revokes another e3db client's permission to read records of the
 // given record type.
 func (c *Client) Unshare(ctx context.Context, recordType string, readerID string) error {
-	// TODO: Need to delete their access key!
-
 	id := c.Options.ClientID
 	u := fmt.Sprintf("%s/v1/storage/policy/%s/%s/%s/%s", c.apiURL(), id, id, readerID, recordType)
 	req, err := http.NewRequest("PUT", u, strings.NewReader(denyReadPolicy))
@@ -425,6 +423,11 @@ func (c *Client) Unshare(ctx context.Context, recordType string, readerID string
 	}
 
 	resp, err := c.rawCall(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	err = c.deleteAccessKey(ctx, id, id, readerID, recordType)
 	if err != nil {
 		return err
 	}

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -171,30 +171,31 @@ func haveSharedWith(id, recordType string) (bool, error) {
 // TestShareThenUnshare should share then revoke sharing
 func TestShareThenUnshare(t *testing.T) {
 	data := make(map[string]string)
+	ctype := "test-share-data-" + base64Encode(randomSecretKey()[:8])
 	data["message"] = "Hello, world!"
-	_, err := client.Write(context.Background(), "test-share-data", data, nil)
+	_, err := client.Write(context.Background(), ctype, data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = client.Share(context.Background(), "test-share-data", clientSharedWithID)
+	err = client.Share(context.Background(), ctype, clientSharedWithID)
 	if err != nil {
 		t.Error(err)
 	}
 
-	isShared, err := haveSharedWith(clientSharedWithID, "test-share-data")
+	isShared, err := haveSharedWith(clientSharedWithID, ctype)
 	if err != nil {
 		t.Errorf("share failed: %s", err)
 	} else if !isShared {
 		t.Error("share: have not shared with client")
 	}
 
-	err = client.Unshare(context.Background(), "test-share-data", clientSharedWithID)
+	err = client.Unshare(context.Background(), ctype, clientSharedWithID)
 	if err != nil {
 		t.Errorf("Unshare failed: %s", err)
 	}
 
-	isShared, err = haveSharedWith(clientSharedWithID, "test-share-data")
+	isShared, err = haveSharedWith(clientSharedWithID, ctype)
 	if err != nil {
 		t.Errorf("unshare failed: %s", err)
 	} else if isShared {

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -139,13 +139,15 @@ func TestWriteThenDelete(t *testing.T) {
 
 func TestShare(t *testing.T) {
 	data := make(map[string]string)
+	ctype := "test-data-" + base64Encode(randomSecretKey()[:8])
+
 	data["message"] = "Hello, world!"
-	_, err := client.Write(context.Background(), "test-data", data, nil)
+	_, err := client.Write(context.Background(), ctype, data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = client.Share(context.Background(), "test-data", clientSharedWithID)
+	err = client.Share(context.Background(), ctype, clientSharedWithID)
 	if err != nil {
 		t.Error(err)
 	}

--- a/crypto.go
+++ b/crypto.go
@@ -324,6 +324,28 @@ func (c *Client) putAccessKey(ctx context.Context, writerID, userID, readerID, r
 	return nil
 }
 
+func (c *Client) deleteAccessKey(ctx context.Context, writerID, userID, readerID, recordType string) error {
+	u := fmt.Sprintf("%s/v1/storage/access_keys/%s/%s/%s/%s", c.apiURL(), writerID, userID, readerID, recordType)
+	req, err := http.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.rawCall(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	defer closeResp(resp)
+
+	if c.akCache != nil {
+		cacheKey := akCacheKey{writerID, userID, recordType}
+		c.akCache[cacheKey] = nil
+	}
+
+	return nil
+}
+
 // decryptRecord modifies a record in-place, decrypting all data fields
 // using an access key granted by an authorizer.
 func (c *Client) decryptRecord(ctx context.Context, record *Record) error {


### PR DESCRIPTION
Ensure the EAK is deleted when sharing is revoked. Also, add a bit of randomness to the content type used in a test to prevent conflicts with previously unshared yet undeleted AKs.

Fixes E3DB-648