### PR TITLE
Update SDK Registration Routine

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,8 +40,8 @@ type ClientOpts struct {
 	ClientEmail string
 	APIKeyID    string
 	APISecret   string
-	PublicKey   publicKey
-	PrivateKey  privateKey
+	PublicKey   PublicKey
+	PrivateKey  PrivateKey
 	APIBaseURL  string
 	Logging     bool
 }
@@ -55,7 +55,7 @@ type Client struct {
 	akCache    map[akCacheKey]secretKey
 }
 
-type clientKey struct {
+type ClientKey struct {
 	Curve25519 string `json:"curve25519"`
 }
 
@@ -63,7 +63,7 @@ type clientKey struct {
 // about a client.
 type ClientInfo struct {
 	ClientID  string    `json:"client_id"`
-	PublicKey clientKey `json:"public_key"`
+	PublicKey ClientKey `json:"public_key"`
 	Validated bool      `json:"validated"`
 }
 
@@ -72,13 +72,13 @@ type ClientDetails struct {
 	ClientID  string    `json:"client_id"`
 	ApiKeyID  string    `json:"api_key_id"`
 	ApiSecret string    `json:"api_secret"`
-	PublicKey clientKey `json:"public_key"`
+	PublicKey ClientKey `json:"public_key"`
 	Name      string    `json:"name"`
 }
 
 type clientRegistrationInfo struct {
 	Name      string    `json:"name"`
-	PublicKey clientKey `json:"public_key"`
+	PublicKey ClientKey `json:"public_key"`
 }
 
 type clientRegistrationRequest struct {
@@ -152,7 +152,7 @@ func GetClient(opts ClientOpts) (*Client, error) {
 }
 
 // RegisterClient creates a new client for a given InnoVault account
-func RegisterClient(registrationToken string, clientName string, publicKey clientKey, apiURL string) (*ClientDetails, error) {
+func RegisterClient(registrationToken string, clientName string, publicKey ClientKey, apiURL string) (*ClientDetails, error) {
 	if apiURL == "" {
 		apiURL = defaultStorageURL
 	}
@@ -304,7 +304,7 @@ func (c *Client) GetClientInfo(ctx context.Context, clientID string) (*ClientInf
 // getClientKey queries the E3DB server for a client's public key
 // given its client UUID. (This was exported in the Java SDK but
 // I'm not sure why since it's rather low level.)
-func (c *Client) getClientKey(ctx context.Context, clientID string) (publicKey, error) {
+func (c *Client) getClientKey(ctx context.Context, clientID string) (PublicKey, error) {
 	info, err := c.GetClientInfo(ctx, clientID)
 	if err != nil {
 		return nil, err

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -47,13 +47,13 @@ func setup() {
 	if err != nil {
 		dieErr(err)
 	}
-	pubKey := clientKey{Curve25519: base64Encode(pub[:])}
+	pubKey := ClientKey{Curve25519: base64Encode(pub[:])}
 
 	pub2, priv2, err := generateKeyPair()
 	if err != nil {
 		dieErr(err)
 	}
-	pubKey2 := clientKey{Curve25519: base64Encode(pub2[:])}
+	pubKey2 := ClientKey{Curve25519: base64Encode(pub2[:])}
 
 	clientDetails, err := RegisterClient(token, clientName, pubKey, apiURL)
 	if err != nil {
@@ -115,7 +115,7 @@ func TestRegistration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pubKey := clientKey{Curve25519: base64Encode(pub[:])}
+	pubKey := ClientKey{Curve25519: base64Encode(pub[:])}
 	clientName := "test-client-" + base64Encode(randomSecretKey()[:8])
 
 	client, err := RegisterClient(token, clientName, pubKey, apiURL)

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 var client *Client
+var clientOpts *ClientOpts
 var altClient *Client
 var clientSharedWithID string
 
@@ -66,7 +67,7 @@ func setup() {
 		dieErr(err)
 	}
 
-	opts := &ClientOpts{
+	clientOpts = &ClientOpts{
 		ClientID:    clientDetails.ClientID,
 		ClientEmail: "",
 		APIKeyID:    clientDetails.ApiKeyID,
@@ -77,17 +78,17 @@ func setup() {
 		Logging:     false,
 	}
 
-	client, err = GetClient(*opts)
+	client, err = GetClient(*clientOpts)
 	if err != nil {
 		dieErr(err)
 	}
-	altClient, err = GetClient(*opts)
+	altClient, err = GetClient(*clientOpts)
 	if err != nil {
 		dieErr(err)
 	}
 
 	// Load another client for later sharing tests
-	opts = &ClientOpts{
+	opts := &ClientOpts{
 		ClientID:    shareClientDetails.ClientID,
 		ClientEmail: "",
 		APIKeyID:    shareClientDetails.ApiKeyID,
@@ -147,6 +148,28 @@ func TestRegistration(t *testing.T) {
 
 	if client.ApiSecret == "" {
 		t.Error("API Secret is not set")
+	}
+}
+
+func TestConfig(t *testing.T) {
+	profile := "p_" + base64Encode(randomSecretKey()[:8])
+
+	if ProfileExists(profile) {
+		t.Error("Profile already exists")
+	}
+
+	err := SaveConfig(profile, clientOpts)
+	if err != nil {
+		t.Error("Unable to save profile")
+	}
+
+	newOpts, err := GetConfig(profile)
+	if err != nil {
+		t.Error("Unable to re-read profile")
+	}
+
+	if newOpts.ClientID != clientOpts.ClientID {
+		t.Error("Invalid profile retrieved")
 	}
 }
 

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -43,13 +43,13 @@ func setup() {
 	clientName := "test-client-" + base64Encode(randomSecretKey()[:8])
 	shareClientName := "share-client-" + base64Encode(randomSecretKey()[:8])
 
-	pub, priv, err := generateKeyPair()
+	pub, priv, err := GenerateKeyPair()
 	if err != nil {
 		dieErr(err)
 	}
 	pubKey := ClientKey{Curve25519: base64Encode(pub[:])}
 
-	pub2, priv2, err := generateKeyPair()
+	pub2, priv2, err := GenerateKeyPair()
 	if err != nil {
 		dieErr(err)
 	}
@@ -110,7 +110,7 @@ func TestRegistration(t *testing.T) {
 	apiURL := os.Getenv("API_URL")
 	token := os.Getenv("REGISTRATION_TOKEN")
 
-	pub, _, err := generateKeyPair()
+	pub, _, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/crypto.go
+++ b/crypto.go
@@ -123,10 +123,10 @@ func secretBoxDecryptFromBase64(ciphertext, nonce string, key secretKey) ([]byte
 const publicKeySize = 32
 const privateKeySize = 32
 
-type publicKey *[publicKeySize]byte
-type privateKey *[privateKeySize]byte
+type PublicKey *[publicKeySize]byte
+type PrivateKey *[privateKeySize]byte
 
-func generateKeyPair() (publicKey, privateKey, error) {
+func generateKeyPair() (PublicKey, PrivateKey, error) {
 	pub, priv, err := box.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, nil, err
@@ -135,7 +135,7 @@ func generateKeyPair() (publicKey, privateKey, error) {
 	return pub, priv, nil
 }
 
-func makePublicKey(b []byte) publicKey {
+func makePublicKey(b []byte) PublicKey {
 	key := [publicKeySize]byte{}
 	copy(key[:], b)
 	return &key
@@ -144,7 +144,7 @@ func makePublicKey(b []byte) publicKey {
 // decodePublicKey decodes a public key from a Base64URL encoded
 // string containing a 256-bit Curve25519 public key, returning an
 // error if the decode operation fails.
-func decodePublicKey(s string) (publicKey, error) {
+func decodePublicKey(s string) (PublicKey, error) {
 	bytes, err := base64Decode(s)
 	if err != nil {
 		return nil, err
@@ -153,11 +153,11 @@ func decodePublicKey(s string) (publicKey, error) {
 	return makePublicKey(bytes), nil
 }
 
-func encodePublicKey(k publicKey) string {
+func encodePublicKey(k PublicKey) string {
 	return base64Encode(k[:])
 }
 
-func makePrivateKey(b []byte) privateKey {
+func makePrivateKey(b []byte) PrivateKey {
 	key := [privateKeySize]byte{}
 	copy(key[:], b)
 	return &key
@@ -166,7 +166,7 @@ func makePrivateKey(b []byte) privateKey {
 // decodePrivateKey decodes a private key from a Base64URL encoded
 // string containing a 256-bit Curve25519 private key, returning an
 // error if the decode operation fails.
-func decodePrivateKey(s string) (privateKey, error) {
+func decodePrivateKey(s string) (PrivateKey, error) {
 	bytes, err := base64Decode(s)
 	if err != nil {
 		return nil, err
@@ -175,17 +175,17 @@ func decodePrivateKey(s string) (privateKey, error) {
 	return makePrivateKey(bytes), nil
 }
 
-func encodePrivateKey(k privateKey) string {
+func encodePrivateKey(k PrivateKey) string {
 	return base64Encode(k[:])
 }
 
-func boxEncryptToBase64(data []byte, pubKey publicKey, privKey privateKey) (string, string) {
+func boxEncryptToBase64(data []byte, pubKey PublicKey, privKey PrivateKey) (string, string) {
 	n := randomNonce()
 	ciphertext := box.Seal(nil, data, n, pubKey, privKey)
 	return base64Encode(ciphertext), base64Encode(n[:])
 }
 
-func boxDecryptFromBase64(ciphertext, nonce string, pubKey publicKey, privKey privateKey) ([]byte, error) {
+func boxDecryptFromBase64(ciphertext, nonce string, pubKey PublicKey, privKey PrivateKey) ([]byte, error) {
 	ciphertextBytes, err := base64Decode(ciphertext)
 	if err != nil {
 		return nil, err
@@ -225,7 +225,7 @@ func (c *Client) putAKCache(akID akCacheKey, k secretKey) {
 type getEAKResponse struct {
 	EAK                 string    `json:"eak"`
 	AuthorizerID        string    `json:"authorizer_id"`
-	AuthorizerPublicKey clientKey `json:"authorizer_public_key"`
+	AuthorizerPublicKey ClientKey `json:"authorizer_public_key"`
 }
 
 type putEAKRequest struct {

--- a/crypto.go
+++ b/crypto.go
@@ -126,7 +126,8 @@ const privateKeySize = 32
 type PublicKey *[publicKeySize]byte
 type PrivateKey *[privateKeySize]byte
 
-func generateKeyPair() (PublicKey, PrivateKey, error) {
+// GenerateKeyPair creates a new Curve25519 keypair for cryptographic operations
+func GenerateKeyPair() (PublicKey, PrivateKey, error) {
 	pub, priv, err := box.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Add support for registration tokens to the SDK and update integration tests:
- Registration via a token is explicitly tested
- Both the test client and sharing client are dynamically registered