### PR TITLE
Update `GenerateKeyPair` to return string literals

### DIFF
--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -49,13 +49,17 @@ func setup() {
 	if err != nil {
 		dieErr(err)
 	}
-	pubKey := ClientKey{Curve25519: base64Encode(pub[:])}
+	pubBytes, _ := base64Decode(pub)
+	privBytes, _ := base64Decode(priv)
+	pubKey := ClientKey{Curve25519: pub}
 
 	pub2, priv2, err := GenerateKeyPair()
 	if err != nil {
 		dieErr(err)
 	}
-	pubKey2 := ClientKey{Curve25519: base64Encode(pub2[:])}
+	pubBytes2, _ := base64Decode(pub2)
+	privBytes2, _ := base64Decode(priv2)
+	pubKey2 := ClientKey{Curve25519: pub2}
 
 	clientDetails, err := RegisterClient(token, clientName, pubKey, apiURL)
 	if err != nil {
@@ -72,8 +76,8 @@ func setup() {
 		ClientEmail: "",
 		APIKeyID:    clientDetails.ApiKeyID,
 		APISecret:   clientDetails.ApiSecret,
-		PublicKey:   pub,
-		PrivateKey:  priv,
+		PublicKey:   makePublicKey(pubBytes),
+		PrivateKey:  makePrivateKey(privBytes),
 		APIBaseURL:  apiURL,
 		Logging:     false,
 	}
@@ -93,8 +97,8 @@ func setup() {
 		ClientEmail: "",
 		APIKeyID:    shareClientDetails.ApiKeyID,
 		APISecret:   shareClientDetails.ApiSecret,
-		PublicKey:   pub2,
-		PrivateKey:  priv2,
+		PublicKey:   makePublicKey(pubBytes2),
+		PrivateKey:  makePrivateKey(privBytes2),
 		APIBaseURL:  apiURL,
 		Logging:     false,
 	}
@@ -121,7 +125,7 @@ func TestRegistration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pubKey := ClientKey{Curve25519: base64Encode(pub[:])}
+	pubKey := ClientKey{Curve25519: pub}
 	clientName := "test-client-" + base64Encode(randomSecretKey()[:8])
 
 	client, err := RegisterClient(token, clientName, pubKey, apiURL)

--- a/crypto.go
+++ b/crypto.go
@@ -123,17 +123,20 @@ func secretBoxDecryptFromBase64(ciphertext, nonce string, key secretKey) ([]byte
 const publicKeySize = 32
 const privateKeySize = 32
 
+// PublicKey is an alias of a 32-byte array representing the public key component
 type PublicKey *[publicKeySize]byte
+
+// PrivateKey is an alias of a 32-byte array representing the private key component
 type PrivateKey *[privateKeySize]byte
 
 // GenerateKeyPair creates a new Curve25519 keypair for cryptographic operations
-func GenerateKeyPair() (PublicKey, PrivateKey, error) {
+func GenerateKeyPair() (string, string, error) {
 	pub, priv, err := box.GenerateKey(rand.Reader)
 	if err != nil {
-		return nil, nil, err
+		return "", "", err
 	}
 
-	return pub, priv, nil
+	return encodePublicKey(pub), encodePrivateKey(priv), nil
 }
 
 func makePublicKey(b []byte) PublicKey {


### PR DESCRIPTION
Based on great feedback from @gstro, normalize the `GenerateKeyPair()` helper function to return Base64URL-encoded strings (instead of raw bytes) so we're consistent between the various SDKs.