### PR TITLE
Cleanup last reference to non go module e3db-go import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/tozny/e3db-go"
+	"github.com/tozny/e3db-go/v2"
 )
 
 func main() {


### PR DESCRIPTION
Was making sure that all docs have been updated for last change
- [x]  https://godoc.org/github.com/tozny/e3db-go
- [x]  https://tozny.com/documentation/e3db/
- [x]  All lines in the package's README except this one...
- [ ]  This one line in the package's README itself 🤦‍♂️ 