### PR TITLE
Features/add support for authorized sharing

### DIFF
--- a/client.go
+++ b/client.go
@@ -1137,7 +1137,7 @@ func (c *ToznySDKV3) AddAuthorizedSharer(ctx context.Context, authorizedSharerCl
 	_, err := c.GetOrCreateAccessKey(ctx, pdsClient.GetOrCreateAccessKeyRequest{
 		WriterID:   c.ClientID,
 		UserID:     c.ClientID,
-		ReaderID:   authorizedSharerClientID,
+		ReaderID:   c.ClientID,
 		RecordType: recordType,
 	})
 	if err != nil {
@@ -1159,6 +1159,32 @@ func (c *ToznySDKV3) RemoveAuthorizedSharer(ctx context.Context, authorizedShare
 		UserID:       c.ClientID,
 		WriterID:     c.ClientID,
 		AuthorizerID: authorizedSharerClientID,
+		RecordType:   recordType,
+	})
+}
+
+// AddAuthorizedSharer adds the specified client as an authorized sharer
+// for records of the specified type written by the authorizing client,
+// returning error (if any).
+func (c *ToznySDKV3) BrokerShare(ctx context.Context, authorizerClientID string, readerClientID string, recordType string) error {
+	return c.AuthorizerShareRecords(ctx, pdsClient.AuthorizerShareRecordsRequest{
+		UserID:       authorizerClientID,
+		WriterID:     authorizerClientID,
+		AuthorizerID: c.ClientID,
+		ReaderID:     readerClientID,
+		RecordType:   recordType,
+	})
+}
+
+// RemoveAuthorizedSharer removes the specified client as an authorized sharer
+// for records of the specified type written by the authorizing client,
+// returning error (if any).
+func (c *ToznySDKV3) UnbrokerShare(ctx context.Context, authorizerClientID string, readerClientID string, recordType string) error {
+	return c.AuthorizerUnshareRecords(ctx, pdsClient.AuthorizerUnshareRecordsRequest{
+		UserID:       authorizerClientID,
+		WriterID:     authorizerClientID,
+		AuthorizerID: c.ClientID,
+		ReaderID:     readerClientID,
 		RecordType:   recordType,
 	})
 }

--- a/cmd/e3db/main.go
+++ b/cmd/e3db/main.go
@@ -643,6 +643,8 @@ func main() {
 	app.Command("delete", "delete a record", cmdDelete)
 	app.Command("share", "share records with another client", cmdShare)
 	app.Command("unshare", "stop sharing records with another client", cmdUnshare)
+	app.Command("authorize", "authorize another client to share records. on behalf of this client", cmdAuthorizeSharer)
+	app.Command("deauthorize", "deauthoize another client to share records on behalf of this client", cmdDeauthorizeSharer)
 	app.Command("policy", "operations on sharing policy", func(cmd *cli.Cmd) {
 		cmd.Command("incoming", "list incoming sharing policy (who shares with me?)", cmdPolicyIncoming)
 		cmd.Command("outgoing", "list outgoing sharing policy (who have I shared with?)", cmdPolicyOutgoing)
@@ -787,5 +789,67 @@ func cmdLogin(cmd *cli.Cmd) {
 			dieErr(err)
 		}
 		fmt.Printf("Account Session Token: %+v\n", accountSession.Token)
+	}
+}
+
+func cmdAuthorizeSharer(cmd *cli.Cmd) {
+	recordType := cmd.String(cli.StringArg{
+		Name:      "TYPE",
+		Desc:      "type of records to authorize another client to share on behalf of the authorizing client.",
+		Value:     "",
+		HideValue: true,
+	})
+
+	clientID := cmd.String(cli.StringArg{
+		Name:      "CLIENT_ID",
+		Desc:      "client unique id or email",
+		Value:     "",
+		HideValue: true,
+	})
+
+	cmd.Action = func() {
+		sdk, err := e3db.GetSDKV3(fmt.Sprintf(e3db.ProfileInterpolationConfigFilePath, *options.Profile))
+		if err != nil {
+			dieErr(err)
+		}
+
+		ctx := context.Background()
+		err = sdk.AddAuthorizedSharer(ctx, *clientID, *recordType)
+		if err != nil {
+			dieErr(err)
+		}
+
+		fmt.Printf("Records of type '%s' are now authorized to be shared by client '%s'\n", *recordType, *clientID)
+	}
+}
+
+func cmdDeauthorizeSharer(cmd *cli.Cmd) {
+	recordType := cmd.String(cli.StringArg{
+		Name:      "TYPE",
+		Desc:      "type of records to de-authorize another client to share on behalf of the authorizing client.",
+		Value:     "",
+		HideValue: true,
+	})
+
+	clientID := cmd.String(cli.StringArg{
+		Name:      "CLIENT_ID",
+		Desc:      "client unique id or email",
+		Value:     "",
+		HideValue: true,
+	})
+
+	cmd.Action = func() {
+		sdk, err := e3db.GetSDKV3(fmt.Sprintf(e3db.ProfileInterpolationConfigFilePath, *options.Profile))
+		if err != nil {
+			dieErr(err)
+		}
+
+		ctx := context.Background()
+		err = sdk.RemoveAuthorizedSharer(ctx, *clientID, *recordType)
+		if err != nil {
+			dieErr(err)
+		}
+
+		fmt.Printf("Records of type '%s' are now de-authorized to be shared by client '%s'\n", *recordType, *clientID)
 	}
 }


### PR DESCRIPTION
- Add sdk methods and command line support authorizing or deauthorizing another client to share the authorizing client's records of a specific type.
- Add methods and cli support for an authorized client to share or unshare on behalf of another client.
- Fix output of ls command to output valid json for empty results

Lets say you have a client, with profile `actor`, and you  write a record with that client

```bash
[octo@ValleyOfTheForge realms]$ e3db -p actor info
Client ID:    8a407178-7543-45da-9d83-effc4d5425aa
Client Email: actor@tozny.com
Public Key:   W8Qi276kbdaUaegGAuxDXKjrFpYRiiGjBASoaEKaCU4
API Key ID:   57814cf7e168dbe4ed5dcf34b820459386a913cd780c47c1e209ee4024934df9
API Secret:   f083c56094c0b6bfff8ad24474b3363c32021cb12df6dbde349d5590678114d5

[octo@ValleyOfTheForge realms]$ cat plain.json 
{
	"tag": "tag2"
}
[octo@ValleyOfTheForge realms]$ cat test.json 
{
"test": "true"
}
[octo@ValleyOfTheForge realms]$ 

[octo@ValleyOfTheForge realms]$ e3db -p actor write --META @plain.json test4 @test.json
e738242a-ead4-4470-9b8d-2edfd1345efd
```

Now imagine you want to authorize another client to share records of this type with other clients
```bash
[octo@ValleyOfTheForge realms]$ e3db -p actor authorize test4 2d742ace-3086-47d5-8bdd-f17327d05dba 
Records of type 'test4' are now authorized to be shared by client '2d742ace-3086-47d5-8bdd-f17327d05dba'
```

Then that client can share records you wrote of that type with other clients
```bash
[octo@ValleyOfTheForge realms]$ e3db info
Client ID:    2d742ace-3086-47d5-8bdd-f17327d05dba
Client Email: authorizer@tozny.com
Public Key:   5bG3N2CR2BLmIQU3bvi9ORfP76jW2164ymIh3Y_08HU
API Key ID:   1152d87e1a2e6007170164412fb7a7580119bfea333c281b919e0c65b2bc9068
API Secret:   8c35734ebe7d0dcc1adf8411e5c6483b9d3b2914d0a242a0ad7cfc6edafa7e47

[octo@ValleyOfTheForge realms]$ e3db broker test4 8a407178-7543-45da-9d83-effc4d5425aa d22892d3-40d1-4c94-b87b-e11b44150442
Records of type 'test4' from client '8a407178-7543-45da-9d83-effc4d5425aa' are now shared with client 'd22892d3-40d1-4c94-b87b-e11b44150442'
```


And that client who had those records shared from the actor client via the authorizer client can read those records!
```bash
[octo@ValleyOfTheForge realms]$ e3db -p ta2One ls
e738242a-ead4-4470-9b8d-2edfd1345efd     test4

[octo@ValleyOfTheForge realms]$ e3db -p ta2One read e738242a-ead4-4470-9b8d-2edfd1345efd 
[
  {
    "meta": {
      "record_id": "e738242a-ead4-4470-9b8d-2edfd1345efd",
      "writer_id": "8a407178-7543-45da-9d83-effc4d5425aa",
      "user_id": "8a407178-7543-45da-9d83-effc4d5425aa",
      "type": "test4",
      "plain": {
        "tag": "tag2"
      },
      "created": "2020-11-27T01:57:39.116491Z",
      "last_modified": "2020-11-27T01:57:39.116491Z",
      "version": "8e10baf3-65f0-4fc5-b6e5-56b74b049f15"
    },
    "data": {
      "test": "true"
    }
  }

]
```

And of course the authorizer can unshare those records of a certain type from the actor client at any time

```
[octo@ValleyOfTheForge realms]$ e3db unbroker test4 8a407178-7543-45da-9d83-effc4d5425aa d22892d3-40d1-4c94-b87b-e11b44150442
Records of type 'test4' from client '8a407178-7543-45da-9d83-effc4d5425aa' are now unshared with client 'd22892d3-40d1-4c94-b87b-e11b44150442'
```

Then client who had those records unshared with won't be able to read those records 
```bash
[octo@ValleyOfTheForge realms]$ e3db -p ta2One read e738242a-ead4-4470-9b8d-2edfd1345efd 
[

]
```

Now imagine how much simpler this could be with groups....stay tuned 😈