### PR TITLE
Adds an execute v2 search method to SDKv3

### DIFF
--- a/client.go
+++ b/client.go
@@ -690,6 +690,7 @@ type ToznySDKV3 struct {
 	ClientID        string
 	CurrentIdentity TozIDSessionIdentityData
 	config          e3dbClients.ClientConfig
+	akCache         map[akCacheKey]e3dbClients.SymmetricKey
 }
 
 // LoggedInIdentityData represents data about the identity session of a given user. Currently that is just realm and
@@ -1615,8 +1616,8 @@ func (c *ToznySDKV3) ReadFile(ctx context.Context, options ReadFileOptions) erro
 	}()
 	// get access key for the record type
 	keyRequest := pdsClient.GetOrCreateAccessKeyRequest{
-		WriterID:   c.E3dbPDSClient.ClientID,
-		UserID:     c.E3dbPDSClient.ClientID,
+		WriterID:   fileResp.Metadata.WriterID,
+		UserID:     fileResp.Metadata.UserID,
 		ReaderID:   c.E3dbPDSClient.ClientID,
 		RecordType: fileResp.Metadata.Type,
 	}
@@ -2078,14 +2079,42 @@ func (c *ToznySDKV3) MakeSecretResponse(secretRecord *pdsClient.Record, groupID 
 	return secret
 }
 
-
-
-// ExecuteSearch takes the given request and returns all records that match that request.
+// ExecuteSearch takes the given request and returns all records that match that request. Record data for non-files is decrypted. Files must be downloaded separately
 func (c *ToznySDKV3) ExecuteSearch(executorRequest *searchExecutorClient.ExecutorQueryRequest) (*[]pdsClient.ListedRecord, error) {
 	client := searchExecutorClient.New(c.config)
 	results, _, err := searchExecutorClient.TimePaginateSearch(client, *executorRequest)
 	if err != nil {
 		return nil, err
 	}
+	rawEncryptionKey, err := e3dbClients.DecodeSymmetricKey(c.E3dbPDSClient.EncryptionKeys.Private.Material)
+	if err != nil {
+		return nil, err
+	}
+	for index, record := range *results {
+		accessKey, err := c.getAKForListedRecord(rawEncryptionKey, record)
+		if err != nil {
+			return nil, err
+		}
+		data, err := e3dbClients.DecryptData(record.Data, accessKey)
+		if err != nil {
+			return nil, err
+		}
+		(*results)[index].Data = data
+	}
 	return results, nil
+}
+
+func (c *ToznySDKV3) getAKForListedRecord(symmetricKey e3dbClients.SymmetricKey, record pdsClient.ListedRecord) (e3dbClients.SymmetricKey, error){
+	if c.akCache == nil {
+		c.akCache = make(map[akCacheKey]e3dbClients.SymmetricKey)
+	}
+	key, exists := c.akCache[akCacheKey{record.Metadata.WriterID, record.Metadata.UserID, record.Metadata.Type}]; if exists {
+		return key, nil
+	}
+	accessKey, err := e3dbClients.DecryptEAK(record.AccessKey.EAK, record.AccessKey.AuthorizerPublicKey.Curve25519, symmetricKey)
+	if err != nil {
+		return nil, err
+	}
+	c.akCache[akCacheKey{record.Metadata.WriterID, record.Metadata.UserID, record.Metadata.Type}] = accessKey
+	return accessKey, nil
 }

--- a/client.go
+++ b/client.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/tozny/e3db-clients-go/searchExecutorClient"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -2075,4 +2076,16 @@ func (c *ToznySDKV3) MakeSecretResponse(secretRecord *pdsClient.Record, groupID 
 		secret.SecretValue = secretRecord.Data[SecretValueDataKey]
 	}
 	return secret
+}
+
+
+
+// ExecuteSearch takes the given request and returns all records that match that request.
+func (c *ToznySDKV3) ExecuteSearch(executorRequest *searchExecutorClient.ExecutorQueryRequest) (*[]pdsClient.ListedRecord, error) {
+	client := searchExecutorClient.New(c.config)
+	results, _, err := searchExecutorClient.TimePaginateSearch(client, *executorRequest)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
 }

--- a/client.go
+++ b/client.go
@@ -2051,7 +2051,7 @@ func (c *ToznySDKV3) DecryptTextSecret(ctx context.Context, secret *pdsClient.Li
 		Data:            secret.Data,
 		RecordSignature: secret.RecordSignature,
 	}
-	decryptedRecord, err := c.E3dbPDSClient.DecryptRecord(ctx, encryptedRecord)
+	decryptedRecord, err := c.E3dbPDSClient.DecryptGroupRecordWithGroupEncryptedAccessKey(ctx, encryptedRecord, secret.AccessKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Underlying implementation currently supports binomial splitting of large result sets
- Updates decryption implementations to better support caching and shared items