### PR TITLE
Share secrets by username

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,13 +37,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tozny/e3db-clients-go/searchExecutorClient"
-
 	e3dbClients "github.com/tozny/e3db-clients-go"
 	"github.com/tozny/e3db-clients-go/accountClient"
 	"github.com/tozny/e3db-clients-go/file"
 	"github.com/tozny/e3db-clients-go/identityClient"
 	"github.com/tozny/e3db-clients-go/pdsClient"
+	"github.com/tozny/e3db-clients-go/searchExecutorClient"
 	"github.com/tozny/e3db-clients-go/storageClient"
 
 	"github.com/google/uuid"

--- a/client.go
+++ b/client.go
@@ -2076,3 +2076,28 @@ func (c *ToznySDKV3) MakeSecretResponse(secretRecord *pdsClient.Record, groupID 
 	}
 	return secret
 }
+
+type ShareSecretInfo struct {
+	SecretName     string
+	SecretType     string
+	UsernamesToAdd []string
+	RealmName      string
+}
+
+func (c *ToznySDKV3) ShareSecretWithUsername(ctx context.Context, params ShareSecretInfo) error {
+	if len(params.UsernamesToAdd) == 0 {
+		return fmt.Errorf("At least one username required.")
+	}
+	// find the username for secret writer if it's someone else
+	searchParams := identityClient.SearchRealmIdentitiesRequest{
+		RealmName:         params.RealmName,
+		IdentityUsernames: params.UsernamesToAdd,
+	}
+	identities, err := c.E3dbIdentityClient.SearchRealmIdentities(ctx, searchParams)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("identities: %+v", identities)
+
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -1961,6 +1961,9 @@ func (c *ToznySDKV3) ListSecrets(ctx context.Context, options ListSecretsOptions
 				if err != nil {
 					return nil, err
 				}
+				if len(identities.SearchedIdentitiesInformation) < 1 {
+					return nil, fmt.Errorf("ListSecrets: no identity found with clientID %s", record.Metadata.WriterID)
+				}
 				username := identities.SearchedIdentitiesInformation[0].RealmUsername
 				record.Metadata.Plain[SecretWriterUsernameMetadataKey] = username
 				record.Metadata.Plain[SecretSharedMetadataKey] = shared
@@ -2103,6 +2106,9 @@ func (c *ToznySDKV3) ShareSecretWithUsername(ctx context.Context, params ShareSe
 	identities, err := c.E3dbIdentityClient.SearchRealmIdentities(ctx, searchParams)
 	if err != nil {
 		return err
+	}
+	if len(identities.SearchedIdentitiesInformation) < 1 {
+		return fmt.Errorf("ShareSecretWithUser: no identity found with username %s", params.UsernameToAdd)
 	}
 	// find or create the group for sharing with UsernameToAdd
 	namespaceOptions := NamespaceOptions{

--- a/client.go
+++ b/client.go
@@ -2162,7 +2162,7 @@ func (c *ToznySDKV3) ShareSecretWithUsername(ctx context.Context, params ShareSe
 	// Find or create the group for sharing with UsernameToAdd
 	namespaceOptions := NamespaceOptions{
 		RealmName:     c.CurrentIdentity.Realm,
-		Namespace:     fmt.Sprintf("%s.%s", c.StorageClient.ClientID, clientID),
+		Namespace:     fmt.Sprintf("%s.%s.%s.%s", c.StorageClient.ClientID, clientID, params.SecretName, params.SecretType),
 		SharingMatrix: sharingMatrix,
 	}
 	group, err := c.GetOrCreateNamespace(ctx, namespaceOptions)

--- a/client.go
+++ b/client.go
@@ -1467,7 +1467,7 @@ func (c *ToznySDKV3) CreateSecret(ctx context.Context, secretDetails CreateSecre
 	}
 	ownerClientID, err := uuid.Parse(c.StorageClient.ClientID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CreateSecret: Client ID must be a valid UUID, got %s", c.StorageClient.ClientID)
 	}
 	// Default permissions for the owner are share & read, but this will be replaced if the user specified permissions
 	permissions := []string{storageClient.ShareContentGroupCapability, storageClient.ReadContentGroupCapability}
@@ -1982,7 +1982,7 @@ func (c *ToznySDKV3) ListSecrets(ctx context.Context, options ListSecretsOptions
 				// find the username for secret writer if it's someone else
 				writerID, err := uuid.Parse(record.Metadata.WriterID)
 				if err != nil {
-					processingErrors = append(processingErrors, fmt.Errorf("WriterID must be a UUID but is %s. Error: %+v", record.Metadata.WriterID, err))
+					processingErrors = append(processingErrors, fmt.Errorf("WriterID must be a UUID but is %s.", record.Metadata.WriterID))
 					continue
 				}
 				searchParams := identityClient.SearchRealmIdentitiesRequest{
@@ -2137,7 +2137,7 @@ func (c *ToznySDKV3) ShareSecretWithUsername(ctx context.Context, params ShareSe
 	sharingMatrix := make(map[uuid.UUID][]string)
 	ownerClientID, err := uuid.Parse(c.StorageClient.ClientID)
 	if err != nil {
-		return err
+		return fmt.Errorf("ShareSecretWithUsername: Client ID must be a valid UUID, got %s", c.StorageClient.ClientID)
 	}
 	// Add default permissions for the calling client to the sharing matrix
 	// If the calling client & permissions were included in UsernameToAddWithPermissions, these will be overwritten

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -42,7 +42,7 @@ func TestListSecrets(t *testing.T) {
 		Limit:     1000,
 		NextToken: 0,
 	}
-	listSecrets, err := sdk.ListSecrets(testCtx, listOptions)
+	listSecrets, _, err := sdk.ListSecrets(testCtx, listOptions)
 	if err != nil {
 		t.Fatalf("Could not list secrets: Err: %+v", err)
 	}
@@ -319,6 +319,16 @@ func TestShareSecretInvalidUsernameFails(t *testing.T) {
 	err = sdk.ShareSecretWithUsername(testCtx, shareOptions)
 	if err == nil {
 		t.Fatal("Should error since username doesn't exist\n")
+	}
+	// share secret with no one
+	shareOptions = ShareSecretInfo{
+		SecretName:                   secret.SecretName,
+		SecretType:                   secret.SecretType,
+		UsernameToAddWithPermissions: map[string][]string{},
+	}
+	err = sdk.ShareSecretWithUsername(testCtx, shareOptions)
+	if err == nil {
+		t.Fatal("Should error since no usernames were included to share with\n")
 	}
 }
 

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -286,6 +286,38 @@ func TestShareSecretByUsernameSucceeds(t *testing.T) {
 	}
 }
 
+func TestShareSecretInvalidUsernameFails(t *testing.T) {
+	request := TozIDLoginRequest{
+		Username:     username,
+		Password:     password,
+		RealmName:    realmName,
+		APIBaseURL:   baseURL,
+		LoginHandler: mfaHandler,
+	}
+	sdk, err := GetSDKV3ForTozIDUser(request)
+	if err != nil {
+		t.Fatalf("Could not log in %+v", err)
+	}
+	viewOptions := ViewSecretOptions{
+		SecretID:   uuid.MustParse(secret1ID),
+		MaxSecrets: 1000,
+	}
+	secret, err := sdk.ViewSecret(testCtx, viewOptions)
+	if err != nil {
+		t.Fatalf("Error viewing shared secret: Err: %+v", err)
+	}
+	// share secret with a username that doesn't exist
+	shareOptions := ShareSecretInfo{
+		SecretName:    secret.SecretName,
+		SecretType:    secret.SecretType,
+		UsernameToAdd: "invalid-user",
+	}
+	err = sdk.ShareSecretWithUsername(testCtx, shareOptions)
+	if err == nil {
+		t.Fatal("Should error since username doesn't exist\n")
+	}
+}
+
 func mfaHandler(sessionResponse *IdentitySessionIntermediateResponse) (LoginActionData, error) {
 	if sessionResponse.LoginActionType == "login-totp" {
 		totpValue := make(map[string]string)

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -264,9 +264,11 @@ func TestShareSecretByUsernameSucceeds(t *testing.T) {
 	}
 	// id 1 shares the secret with id 2
 	shareOptions := ShareSecretInfo{
-		SecretName:    secretCreated.SecretName,
-		SecretType:    secretCreated.SecretType,
-		UsernameToAdd: username,
+		SecretName: secretCreated.SecretName,
+		SecretType: secretCreated.SecretType,
+		UsernameToAddWithPermissions: map[string][]string{
+			username: {"SHARE_CONTENT", "READ_CONTENT"},
+		},
 	}
 	err = sdk.ShareSecretWithUsername(testCtx, shareOptions)
 	if err != nil {
@@ -279,7 +281,7 @@ func TestShareSecretByUsernameSucceeds(t *testing.T) {
 	}
 	secretView, err := sdk2.ViewSecret(testCtx, viewOptions)
 	if err != nil {
-		t.Fatalf("Error viewing shared secret: Err: %+v", err)
+		t.Fatalf("Error viewing shared secret: %+v", err)
 	}
 	if secretReq.SecretValue != secretView.SecretValue {
 		t.Fatalf("SecretValue doesn't match. Created: %s Viewed: %s", secretCreated.Record.Data["secretValue"], secretView.Record.Data["secretValue"])
@@ -304,13 +306,15 @@ func TestShareSecretInvalidUsernameFails(t *testing.T) {
 	}
 	secret, err := sdk.ViewSecret(testCtx, viewOptions)
 	if err != nil {
-		t.Fatalf("Error viewing shared secret: Err: %+v", err)
+		t.Fatalf("Error viewing shared secret: %+v", err)
 	}
 	// share secret with a username that doesn't exist
 	shareOptions := ShareSecretInfo{
-		SecretName:    secret.SecretName,
-		SecretType:    secret.SecretType,
-		UsernameToAdd: "invalid-user",
+		SecretName: secret.SecretName,
+		SecretType: secret.SecretType,
+		UsernameToAddWithPermissions: map[string][]string{
+			"invalid-user": {"SHARE_CONTENT", "READ_CONTENT"},
+		},
 	}
 	err = sdk.ShareSecretWithUsername(testCtx, shareOptions)
 	if err == nil {


### PR DESCRIPTION
Share secrets with identities by username, with a test.

DecryptTextSecret was updated to use the group eak, so that it can decrypt secrets that are owned or shared with the identity.