### PR TITLE
[WASH-1124] add AgentToken to SDK

### DIFF
--- a/config.go
+++ b/config.go
@@ -203,10 +203,13 @@ type ToznySDKJSONConfig struct {
 	// Embed all config for v1 and v2 clients
 	ConfigFile
 	TozIDSessionIdentityData `json:"toz_id_session_identity_data"`
-	PublicSigningKey  string `json:"public_signing_key"`
-	PrivateSigningKey string `json:"private_signing_key"`
-	AccountUsername   string `json:"account_user_name"`
-	AccountPassword   string `json:"account_password"`
+	PublicSigningKey         string `json:"public_signing_key"`
+	PrivateSigningKey        string `json:"private_signing_key"`
+	AccountUsername          string `json:"account_user_name"`
+	AccountPassword          string `json:"account_password"`
+	// TozIDRealmIDPAccessToken is populated during the login process.
+	// The token can expire so is purposefully not preserved in the saved JSON, and so can be empty.
+	TozIDRealmIDPAccessToken *string
 }
 
 // LoadConfigFile loads JSON configuration for a Tozny SDK from the file


### PR DESCRIPTION
The AgentToken is named as such to emulate the js-sdk. It is a jwt for
the tozid-realm-idp agent client which is returned in the final redirect
response of the login flow when logging into the account client.

An auth pattern exists in keycloak to use it to maintain a user's session
across API calls. It will be needed for automated testing of WebAuthn MFA
and for supporting FIDO2 devices in TODA.