### PR TITLE
update e3db-clients-go

### DIFF
--- a/client.go
+++ b/client.go
@@ -904,11 +904,11 @@ func GetSDKV3ForTozIDUser(login TozIDLoginRequest) (*ToznySDKV3, error) {
 	redirectRequest := identityClient.IdentityLoginRedirectRequest{
 		RealmName: realmInfo.Domain,
 		// The following map values if not present will be set to the empty string and identity service will handle appropriately
-		SessionCode:   sessionResponse.Context["session_code"],
-		Execution:     sessionResponse.Context["execution"],
-		TabID:         sessionResponse.Context["tab_id"],
-		ClientID:      sessionResponse.Context["client_id"],
-		AuthSessionId: sessionResponse.Context["auth_session_id"],
+		SessionCode:   sessionResponse.Context["session_code"].(string),
+		Execution:     sessionResponse.Context["execution"].(string),
+		TabID:         sessionResponse.Context["tab_id"].(string),
+		ClientID:      sessionResponse.Context["client_id"].(string),
+		AuthSessionId: sessionResponse.Context["auth_session_id"].(string),
 	}
 	redirect, err := idClient.IdentityLoginRedirect(ctx, redirectRequest)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jawher/mow.cli v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.7.0 // indirect
-	github.com/tozny/e3db-clients-go v0.0.159
+	github.com/tozny/e3db-clients-go v0.0.201
 	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf
 	golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c
 )

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tozny/e3db-clients-go v0.0.159 h1:MaLxrY33tnpum+ueud9z+NgEAIVNcrgzYcL1BOxbomI=
-github.com/tozny/e3db-clients-go v0.0.159/go.mod h1:yNs03BRVrLCEZzRze0CjYkrMaC5SLIxPn0li1ZHHVW4=
+github.com/tozny/e3db-clients-go v0.0.201 h1:Lppu6NY1CZoRmmZu6yq3B32eRmWR6t5qnS/BpzcwIEM=
+github.com/tozny/e3db-clients-go v0.0.201/go.mod h1:yNs03BRVrLCEZzRze0CjYkrMaC5SLIxPn0li1ZHHVW4=
 github.com/tozny/utils-go v0.0.51 h1:2BG0JFK5Hcz6Q2FoXOMlc3iivPtnYAPtWMDJIKxlGok=
 github.com/tozny/utils-go v0.0.51/go.mod h1:LVe397WORTz2JneKLq3CjHgcV80HbBup+iNwrdP8Yus=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=


### PR DESCRIPTION
checking in the updates required to release WebAuthn security keys. using published version of e3db-clients-go